### PR TITLE
Remove pnpm-lock.yaml from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ yarn-error.log
 yarn.lock
 .yarnrc.yml
 .pnpm-store
-pnpm-lock.yaml
 
 # Turbo
 .turbo


### PR DESCRIPTION
## Summary
- Removed pnpm-lock.yaml from .gitignore
- Lock files should be tracked in version control to ensure dependency consistency across developers and CI environments

## Reasoning
- The lock file was previously ignored yet still tracked in git
- This change ensures the gitignore configuration matches the intended behavior
- Lock files provide deterministic builds and prevent "works on my machine" issues

🤖 Generated with [Claude Code](https://claude.ai/code)