### PR TITLE
Add Firebase Firestore and Storage rules configuration

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -17,5 +17,12 @@
     "ui": {
       "enabled": true
     }
+  },
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "storage": {
+    "rules": "storage.rules"
   }
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,12 @@
+rules_version = '2';
+
+// Craft rules based on data in your Firestore database
+// allow write: if firestore.get(
+//    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add initial Firestore rules with secure default configuration (deny all access)
- Add initial Storage rules with secure default configuration (deny all access)
- Add Firestore indexes configuration file
- Update firebase.json to include Firestore and Storage configurations

## Test plan
- [ ] Verify Firebase deployment includes these rules
- [ ] Confirm secure default settings prevent unauthorized access