### PR TITLE
CommandSchema を必須フィールドに変更し型の冗長性を排除

### DIFF
--- a/apps/web/src/models/CommandHistory.ts
+++ b/apps/web/src/models/CommandHistory.ts
@@ -4,12 +4,14 @@ export const CommandSchema = z.object({
   command: z.string().min(1, 'Command is required'),
   timestamp: z.date().optional(),
   userId: z.string().optional(), // ユーザーIDは認証情報から取得
-  status: z.enum(['success', 'error', 'pending']).default('pending'),
+  // statusは必須フィールド（undefined不可）
+  status: z.enum(['success', 'error', 'pending']),
   output: z.string().optional(),
   workingDirectory: z.string().optional(),
   environment: z.record(z.string()).optional(),
 });
 
+// Zodスキーマから型を自動生成して使用
 export type Command = z.infer<typeof CommandSchema>;
 
 // Firestoreのコレクションパスは奇数セグメントである必要がある

--- a/apps/web/src/repositories/CommandHistoryRepository.ts
+++ b/apps/web/src/repositories/CommandHistoryRepository.ts
@@ -4,32 +4,21 @@ import {
   createEventSourcedRepository,
 } from '@web-shell/firestore-generator';
 import type { Firestore } from 'firebase/firestore';
-import { COMMAND_HISTORY_COLLECTION, CommandSchema } from '../models/CommandHistory';
-
-// Commandの型をより厳密に定義（statusはundefinedを許容しない）
-type StrictCommand = {
-  command: string;
-  status: 'success' | 'error' | 'pending';
-  timestamp?: Date;
-  userId?: string;
-  output?: string;
-  workingDirectory?: string;
-  environment?: Record<string, string>;
-};
+import { COMMAND_HISTORY_COLLECTION, type Command, CommandSchema } from '../models/CommandHistory';
 
 // シングルトンインスタンスを保持
-let repositoryInstance: EventSourcedRepository<StrictCommand> | null = null;
+let repositoryInstance: EventSourcedRepository<Command> | null = null;
 
 // コマンド履歴のリポジトリを作成する関数
 export const createCommandHistoryRepository = (db: Firestore) => {
   // 既存のインスタンスがあれば再利用
   if (!repositoryInstance) {
-    // CommandSchema から作成するが、内部では StrictCommand として扱う
+    // CommandSchemaから直接リポジトリを作成
     repositoryInstance = createEventSourcedRepository(
       db,
       COMMAND_HISTORY_COLLECTION,
       CommandSchema
-    ) as unknown as EventSourcedRepository<StrictCommand>;
+    );
   }
 
   return repositoryInstance;


### PR DESCRIPTION
## 概要
- statusフィールドをデフォルト値なしの必須フィールドに変更
- CommandWithRequiredStatus型を削除して型キャストを排除
- より型安全になるようリファクタリング

## テスト手順
- [x] 型チェックを実行（`pnpm check:ts`）
- [x] ビルドを実行（`pnpm build`）
- [x] リントを実行（`pnpm lint`）
- [x] テストを実行（`pnpm test`）

🤖 Generated with [Claude Code](https://claude.ai/code)