### PR TITLE
Clarify repository type dependencies

### DIFF
--- a/apps/web/src/components/Shell/Shell.tsx
+++ b/apps/web/src/components/Shell/Shell.tsx
@@ -5,7 +5,10 @@ import { IoMdSend } from 'react-icons/io';
 import { db } from '../../firebase/config';
 import { useAuth } from '../../hooks/useAuth';
 import type { Command } from '../../models/CommandHistory';
-import { createCommandHistoryRepository } from '../../repositories/CommandHistoryRepository';
+import {
+  type CommandDocument,
+  createCommandHistoryRepository,
+} from '../../repositories/CommandHistoryRepository';
 
 export default function Shell() {
   const [command, setCommand] = useState('');
@@ -40,11 +43,11 @@ export default function Shell() {
         // 新しいコマンドを先頭に表示するよう並び替え
         setCommandHistory(
           history
-            .map((item) => ({
+            .map((item: CommandDocument) => ({
               command: item.command,
               timestamp: item.clientTimestamp,
               userId: item.userId,
-              status: item.status as 'success' | 'error' | 'pending',
+              status: item.status,
               output: item.output,
               workingDirectory: item.workingDirectory,
             }))

--- a/apps/web/src/repositories/CommandHistoryRepository.ts
+++ b/apps/web/src/repositories/CommandHistoryRepository.ts
@@ -1,6 +1,7 @@
-// 修正済み：@web-shell/firestore-generatorからのインポート
+// @web-shell/firestore-generatorからのインポート
 import {
   type EventSourcedRepository,
+  type FirestoreDocument,
   createEventSourcedRepository,
 } from '@web-shell/firestore-generator';
 import type { Firestore } from 'firebase/firestore';
@@ -23,3 +24,6 @@ export const createCommandHistoryRepository = (db: Firestore) => {
 
   return repositoryInstance;
 };
+
+// コマンド履歴のドキュメントの型をエクスポート
+export type CommandDocument = FirestoreDocument<Command>;


### PR DESCRIPTION
## Summary
- Import FirestoreDocument type directly from firestore-generator
- Define CommandDocument type in the repository layer
- Improve type safety in Shell component (add explicit type annotations)
- Remove type casting for better type consistency

## Testing
- [x] Run type checking (`pnpm check:ts`)
- [x] Run linting (`pnpm lint`)
- [x] Run build (`pnpm build`)
- [x] Run tests (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.ai/code)