### PR TITLE
Refactor firestore-generator for better tree shaking

### DIFF
--- a/packages/firestore-generator/src/events.ts
+++ b/packages/firestore-generator/src/events.ts
@@ -1,6 +1,6 @@
 import {
   type Firestore,
-  QueryConstraint,
+  type QueryConstraint,
   Timestamp,
   addDoc,
   collection,
@@ -12,6 +12,7 @@ import {
   where,
 } from 'firebase/firestore';
 import { v4 as uuidv4 } from 'uuid';
+// Import z as a value since we need schema.parse() runtime functionality
 import { z } from 'zod';
 import type { EventCollection, EventDocument, EventType, FirestoreDocument } from './types';
 import { serverTimestamp } from './utils';
@@ -21,7 +22,16 @@ export type CreateEvent<T> = EventDocument<T, 'create'>;
 export type UpdateEvent<T> = EventDocument<T & { changes: Partial<T> }, 'update'>;
 export type DeleteEvent<T> = EventDocument<{ id: string }, 'delete'>;
 
-// Helper to create an event document
+/**
+ * イベントドキュメントを作成する
+ * @param db Firestoreインスタンス
+ * @param eventCollection イベントコレクション
+ * @param entityId エンティティID
+ * @param type イベントタイプ
+ * @param data イベントデータ
+ * @param metadata 追加メタデータ（オプション）
+ * @returns 作成されたイベントドキュメントのID
+ */
 export async function createEvent<T, E extends EventType>(
   db: Firestore,
   eventCollection: EventCollection<T, E>,
@@ -44,7 +54,13 @@ export async function createEvent<T, E extends EventType>(
   return docRef.id;
 }
 
-// Helper to get all events for an entity
+/**
+ * エンティティのすべてのイベントを取得する
+ * @param db Firestoreインスタンス
+ * @param eventCollection イベントコレクション
+ * @param entityId エンティティID
+ * @returns エンティティのイベント配列
+ */
 export async function getEntityEvents<T, E extends EventType>(
   db: Firestore,
   eventCollection: EventCollection<T, E>,
@@ -60,7 +76,13 @@ export async function getEntityEvents<T, E extends EventType>(
   return querySnapshot.docs.map((doc) => doc.data());
 }
 
-// Helper to get the latest entity state by reconstructing from events
+/**
+ * エンティティの最新状態をイベントから再構築して取得する
+ * @param db Firestoreインスタンス
+ * @param eventCollection イベントコレクション
+ * @param entityId エンティティID
+ * @returns 最新のエンティティ状態または存在しない場合はnull
+ */
 export async function getLatestEntityState<T>(
   db: Firestore,
   eventCollection: EventCollection<T>,
@@ -110,7 +132,14 @@ export async function getLatestEntityState<T>(
   return currentState as FirestoreDocument<T>;
 }
 
-// Create a new entity
+/**
+ * 新しいエンティティを作成する
+ * @param db Firestoreインスタンス
+ * @param eventCollection イベントコレクション
+ * @param data エンティティデータ
+ * @param entityId エンティティID（指定しない場合は自動生成）
+ * @returns 作成されたエンティティのID
+ */
 export async function createEntity<T>(
   db: Firestore,
   eventCollection: EventCollection<T, 'create'>,
@@ -121,7 +150,14 @@ export async function createEntity<T>(
   return entityId;
 }
 
-// Update an existing entity
+/**
+ * 既存のエンティティを更新する
+ * @param db Firestoreインスタンス
+ * @param eventCollection イベントコレクション
+ * @param entityId エンティティID
+ * @param changes 変更内容
+ * @param currentData 現在のエンティティデータ
+ */
 export async function updateEntity<T>(
   db: Firestore,
   eventCollection: EventCollection<T & { changes: Partial<T> }, 'update'>,
@@ -132,7 +168,12 @@ export async function updateEntity<T>(
   await createEvent(db, eventCollection, entityId, 'update', { ...currentData, changes });
 }
 
-// Delete an entity
+/**
+ * エンティティを削除する
+ * @param db Firestoreインスタンス
+ * @param eventCollection イベントコレクション
+ * @param entityId 削除するエンティティのID
+ */
 export async function deleteEntity<T>(
   db: Firestore,
   eventCollection: EventCollection<{ id: string }, 'delete'>,

--- a/packages/firestore-generator/src/generator.ts
+++ b/packages/firestore-generator/src/generator.ts
@@ -8,44 +8,63 @@ import {
   doc,
   query,
 } from 'firebase/firestore';
+// Import z as a value since we need schema.parse() runtime functionality
 import type { z } from 'zod';
-import {
-  type EventCollection,
-  type EventDocument,
-  type EventType,
-  type FirestoreCollection,
-  type FirestoreDocument,
-  FirestoreDocumentInput,
-  type FirestoreGenerator,
+import type {
+  EventCollection,
+  EventDocument,
+  EventType,
+  FirestoreCollection,
+  FirestoreDocument,
 } from './types';
 import { createConverter, createEventConverter } from './utils';
 
-export function createFirestoreGenerator(): FirestoreGenerator {
+/**
+ * 新しいFirestoreコレクションを作成する
+ * @param collectionName コレクション名
+ * @param schema Zodスキーマ
+ * @returns Firestoreコレクションオブジェクト
+ */
+export function createCollection<T>(
+  collectionName: string,
+  schema: z.ZodType<T>
+): FirestoreCollection<T> {
+  const converter = createConverter<T>(schema);
+
+  // コレクションの参照を取得する関数
+  function getCollectionRef(db: Firestore): CollectionReference<FirestoreDocument<T>> {
+    return collection(db, collectionName).withConverter(converter);
+  }
+
+  // ドキュメントの参照を取得する関数
+  function getDocumentRef(db: Firestore, id: string): DocumentReference<FirestoreDocument<T>> {
+    return doc(getCollectionRef(db), id);
+  }
+
+  // クエリを構築する関数
+  function buildQuery(
+    db: Firestore,
+    ...constraints: QueryConstraint[]
+  ): Query<FirestoreDocument<T>> {
+    return query(getCollectionRef(db), ...constraints);
+  }
+
   return {
-    createCollection<T>(collectionName: string, schema: z.ZodType<T>): FirestoreCollection<T> {
-      const converter = createConverter<T>(schema);
-
-      return {
-        collectionName,
-        schema,
-        converter,
-
-        ref(db: Firestore): CollectionReference<FirestoreDocument<T>> {
-          return collection(db, collectionName).withConverter(converter);
-        },
-
-        doc(db: Firestore, id: string): DocumentReference<FirestoreDocument<T>> {
-          return doc(this.ref(db), id);
-        },
-
-        query(db: Firestore, ...constraints: QueryConstraint[]): Query<FirestoreDocument<T>> {
-          return query(this.ref(db), ...constraints);
-        },
-      };
-    },
+    collectionName,
+    schema,
+    converter,
+    ref: getCollectionRef,
+    doc: getDocumentRef,
+    query: buildQuery,
   };
 }
 
+/**
+ * イベントコレクションファクトリーを作成する
+ * @param baseCollectionName ベースコレクション名
+ * @param schema Zodスキーマ
+ * @returns イベントコレクションオブジェクト
+ */
 export function createEventCollectionFactory<T, E extends EventType = EventType>(
   baseCollectionName: string,
   schema: z.ZodType<T>
@@ -53,24 +72,30 @@ export function createEventCollectionFactory<T, E extends EventType = EventType>
   const eventCollectionName = `${baseCollectionName}_events`;
   const converter = createEventConverter<T, E>(schema);
 
+  // イベントコレクションの参照を取得する関数
+  function getEventCollectionRef(db: Firestore): CollectionReference<EventDocument<T, E>> {
+    return collection(db, eventCollectionName).withConverter(converter);
+  }
+
+  // イベントドキュメントの参照を取得する関数
+  function getEventDocumentRef(db: Firestore, id: string): DocumentReference<EventDocument<T, E>> {
+    return doc(getEventCollectionRef(db), id);
+  }
+
+  // イベントクエリを構築する関数
+  function buildEventQuery(
+    db: Firestore,
+    ...constraints: QueryConstraint[]
+  ): Query<EventDocument<T, E>> {
+    return query(getEventCollectionRef(db), ...constraints);
+  }
+
   return {
     collectionName: eventCollectionName,
     schema,
     converter,
-
-    ref(db: Firestore): CollectionReference<EventDocument<T, E>> {
-      return collection(db, eventCollectionName).withConverter(converter);
-    },
-
-    doc(db: Firestore, id: string): DocumentReference<EventDocument<T, E>> {
-      return doc(this.ref(db), id);
-    },
-
-    query(db: Firestore, ...constraints: QueryConstraint[]): Query<EventDocument<T, E>> {
-      return query(this.ref(db), ...constraints);
-    },
+    ref: getEventCollectionRef,
+    doc: getEventDocumentRef,
+    query: buildEventQuery,
   };
 }
-
-// Create a singleton instance
-export const firestoreGenerator = createFirestoreGenerator();

--- a/packages/firestore-generator/src/repository.ts
+++ b/packages/firestore-generator/src/repository.ts
@@ -1,7 +1,7 @@
 import {
-  DocumentReference,
+  type DocumentReference,
   type Firestore,
-  QueryConstraint,
+  type QueryConstraint,
   collection,
   doc,
   getDocs,
@@ -10,6 +10,7 @@ import {
   where,
 } from 'firebase/firestore';
 import { v4 as uuidv4 } from 'uuid';
+// Import z as a value since we need schema.parse() runtime functionality
 import { z } from 'zod';
 import {
   createEntity,
@@ -20,8 +21,12 @@ import {
   updateEntity,
 } from './events';
 import { createEventCollectionFactory } from './generator';
-import { EventCollection, type EventDocument, EventType, type FirestoreDocument } from './types';
+import type { EventCollection, EventDocument, EventType, FirestoreDocument } from './types';
 
+/**
+ * イベントソースドリポジトリの基本インターフェイス
+ * 個々の関数に分割して、ツリーシェイキングを可能にする
+ */
 export interface EventSourcedRepository<T> {
   create(data: T): Promise<string>;
   findById(id: string): Promise<FirestoreDocument<T> | null>;
@@ -31,6 +36,13 @@ export interface EventSourcedRepository<T> {
   getHistory(id: string): Promise<EventDocument<unknown>[]>;
 }
 
+/**
+ * イベントソーシングリポジトリを作成する
+ * @param db Firestoreインスタンス
+ * @param collectionName コレクション名
+ * @param schema Zodスキーマ
+ * @returns イベントソーシングリポジトリインターフェイス
+ */
 export function createEventSourcedRepository<T>(
   db: Firestore,
   collectionName: string,
@@ -40,10 +52,8 @@ export function createEventSourcedRepository<T>(
   const createEventsCollection = createEventCollectionFactory<T, 'create'>(collectionName, schema);
 
   // Create a schema for T & { changes: Partial<T> } without using .extend or .partial
-  // which might not be available on all ZodType instances
   const schemaWithChanges = z.object({
     // We can't assume schema has a shape property, so make this more flexible
-    // Create a changes field that accepts any partial of T
     changes: z.any(),
   });
 
@@ -60,77 +70,113 @@ export function createEventSourcedRepository<T>(
   // Generic events collection for querying all events
   const allEventsCollection = createEventCollectionFactory(collectionName, schema);
 
+  /**
+   * 新しいエンティティを作成する
+   * @param data 作成するデータ
+   * @returns 作成されたエンティティのID
+   */
+  async function createNewEntity(data: T): Promise<string> {
+    try {
+      // Validate data against schema
+      schema.parse(data);
+
+      // Generate a new entity ID
+      const entityId = uuidv4();
+
+      // Create the entity
+      await createEntity(db, createEventsCollection, data, entityId);
+
+      return entityId;
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new Error(`Validation error: ${JSON.stringify(error.errors)}`);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * IDによるエンティティの検索
+   * @param id エンティティID
+   * @returns エンティティオブジェクトまたはnull
+   */
+  async function findEntityById(id: string): Promise<FirestoreDocument<T> | null> {
+    return getLatestEntityState(db, allEventsCollection, id);
+  }
+
+  /**
+   * すべてのエンティティを取得
+   * @returns エンティティオブジェクトの配列
+   */
+  async function findAllEntities(): Promise<FirestoreDocument<T>[]> {
+    // Get all create events to get all entity IDs
+    const createEventsQuery = query(createEventsCollection.ref(db));
+
+    const createEvents = await getDocs(createEventsQuery);
+    const entityIds = createEvents.docs.map((doc) => doc.data().entityId);
+
+    // Get the latest state for each entity
+    const results: FirestoreDocument<T>[] = [];
+
+    for (const id of entityIds) {
+      const entity = await findEntityById(id);
+      if (entity) {
+        results.push(entity);
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * エンティティを更新する
+   * @param id エンティティID
+   * @param changes 変更内容
+   */
+  async function updateEntityById(id: string, changes: Partial<T>): Promise<void> {
+    // Get the current state
+    const currentState = await findEntityById(id);
+
+    if (!currentState) {
+      throw new Error(`Entity with ID ${id} not found`);
+    }
+
+    // Create update event
+    await updateEntity(db, updateEventsCollection, id, changes, currentState);
+  }
+
+  /**
+   * エンティティを削除する
+   * @param id エンティティID
+   */
+  async function deleteEntityById(id: string): Promise<void> {
+    // Check if entity exists
+    const currentState = await findEntityById(id);
+
+    if (!currentState) {
+      throw new Error(`Entity with ID ${id} not found`);
+    }
+
+    // Create delete event
+    await deleteEntity(db, deleteEventsCollection, id);
+  }
+
+  /**
+   * エンティティの履歴を取得する
+   * @param id エンティティID
+   * @returns イベントドキュメントの配列
+   */
+  async function getEntityHistory(id: string): Promise<EventDocument<unknown>[]> {
+    return getEntityEvents(db, allEventsCollection, id);
+  }
+
+  // 公開するインターフェイスを返す
   return {
-    async create(data: T): Promise<string> {
-      try {
-        // Validate data against schema
-        schema.parse(data);
-
-        // Generate a new entity ID
-        const entityId = uuidv4();
-
-        // Create the entity
-        await createEntity(db, createEventsCollection, data, entityId);
-
-        return entityId;
-      } catch (error) {
-        if (error instanceof z.ZodError) {
-          throw new Error(`Validation error: ${JSON.stringify(error.errors)}`);
-        }
-        throw error;
-      }
-    },
-
-    async findById(id: string): Promise<FirestoreDocument<T> | null> {
-      return getLatestEntityState(db, allEventsCollection, id);
-    },
-
-    async findAll(): Promise<FirestoreDocument<T>[]> {
-      // Get all create events to get all entity IDs
-      const createEventsQuery = query(createEventsCollection.ref(db));
-
-      const createEvents = await getDocs(createEventsQuery);
-      const entityIds = createEvents.docs.map((doc) => doc.data().entityId);
-
-      // Get the latest state for each entity
-      const results: FirestoreDocument<T>[] = [];
-
-      for (const id of entityIds) {
-        const entity = await this.findById(id);
-        if (entity) {
-          results.push(entity);
-        }
-      }
-
-      return results;
-    },
-
-    async update(id: string, changes: Partial<T>): Promise<void> {
-      // Get the current state
-      const currentState = await this.findById(id);
-
-      if (!currentState) {
-        throw new Error(`Entity with ID ${id} not found`);
-      }
-
-      // Create update event
-      await updateEntity(db, updateEventsCollection, id, changes, currentState);
-    },
-
-    async delete(id: string): Promise<void> {
-      // Check if entity exists
-      const currentState = await this.findById(id);
-
-      if (!currentState) {
-        throw new Error(`Entity with ID ${id} not found`);
-      }
-
-      // Create delete event
-      await deleteEntity(db, deleteEventsCollection, id);
-    },
-
-    async getHistory(id: string): Promise<EventDocument<unknown>[]> {
-      return getEntityEvents(db, allEventsCollection, id);
-    },
+    create: createNewEntity,
+    findById: findEntityById,
+    findAll: findAllEntities,
+    update: updateEntityById,
+    delete: deleteEntityById,
+    getHistory: getEntityHistory,
   };
 }

--- a/packages/firestore-generator/src/types.ts
+++ b/packages/firestore-generator/src/types.ts
@@ -30,10 +30,6 @@ export interface FirestoreCollection<T> {
   query: (db: Firestore, ...constraints: QueryConstraint[]) => Query<FirestoreDocument<T>>;
 }
 
-export interface FirestoreGenerator {
-  createCollection: <T>(collectionName: string, schema: z.ZodType<T>) => FirestoreCollection<T>;
-}
-
 export type TimestampFields = {
   serverTimestamp: Date | null;
   clientTimestamp: Date;

--- a/packages/firestore-generator/src/utils.ts
+++ b/packages/firestore-generator/src/utils.ts
@@ -10,6 +10,7 @@ import {
   type WithFieldValue,
   serverTimestamp as firestoreServerTimestamp,
 } from 'firebase/firestore';
+// Import z as a value since we need schema.parse() runtime functionality
 import { z } from 'zod';
 import type {
   EventDocument,
@@ -19,150 +20,207 @@ import type {
   FirestoreDocumentInput,
 } from './types';
 
+/**
+ * Firestoreタイムスタンプをjavascript Dateに変換する
+ * @param timestamp Firestoreのタイムスタンプ
+ * @returns 変換されたDateオブジェクト
+ */
 export function timestampToDate(timestamp: Timestamp): Date {
   return timestamp.toDate();
 }
 
+/**
+ * javascript DateをFirestoreタイムスタンプに変換する
+ * @param date 変換するDateオブジェクト
+ * @returns Firestoreタイムスタンプ
+ */
 export function dateToTimestamp(date: Date): Timestamp {
   return Timestamp.fromDate(date);
 }
 
+/**
+ * Firestoreのサーバータイムスタンプ関数のエクスポート
+ */
 export const serverTimestamp = firestoreServerTimestamp;
 
+/**
+ * Firestoreドキュメント用のコンバーターを作成する
+ * @param schema ドキュメントのZodスキーマ
+ * @returns Firestoreデータコンバーター
+ */
 export function createConverter<T>(
   schema: z.ZodType<T>
 ): FirestoreDataConverter<FirestoreDocument<T>> {
+  /**
+   * オブジェクトをFirestoreデータ形式に変換する
+   * @param modelObject 変換するモデルオブジェクト
+   * @returns Firestoreデータ
+   */
+  function toFirestore(modelObject: WithFieldValue<FirestoreDocument<T>>): DocumentData {
+    const now = new Date();
+
+    const data = {
+      ...modelObject,
+      clientTimestamp: now,
+      serverTimestamp: null, // This will be set by the server
+    };
+
+    try {
+      // We don't validate the full document here because the server timestamp will be null
+      return data;
+    } catch (error) {
+      console.error('Validation error:', error);
+      throw new Error(
+        `Document validation failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  /**
+   * Firestoreデータをアプリケーションモデルオブジェクトに変換する
+   * @param snapshot Firestoreのクエリドキュメントスナップショット
+   * @param options スナップショットオプション
+   * @returns 変換されたFirestoreドキュメント
+   */
+  function fromFirestore(
+    snapshot: QueryDocumentSnapshot<DocumentData>,
+    options?: SnapshotOptions
+  ): FirestoreDocument<T> {
+    const data = snapshot.data(options);
+
+    // Convert Firestore Timestamps to Dates
+    const cleanedData = {
+      ...data,
+      id: snapshot.id,
+      serverTimestamp:
+        data.serverTimestamp instanceof Timestamp
+          ? timestampToDate(data.serverTimestamp)
+          : data.serverTimestamp,
+      clientTimestamp:
+        data.clientTimestamp instanceof Timestamp
+          ? timestampToDate(data.clientTimestamp)
+          : data.clientTimestamp,
+    };
+
+    try {
+      // Create a new schema that includes the required fields
+      // without assuming schema has a shape property
+      const fullDocSchema = z
+        .object({
+          id: z.string(),
+          serverTimestamp: z.date().nullable(),
+          clientTimestamp: z.date(),
+          // Remaining fields from T will be handled via any
+          // since we can't reliably extract them from an arbitrary ZodType
+        })
+        .passthrough() as unknown as z.ZodType<FirestoreDocument<T>>;
+
+      // Validate the document matches our schema
+      return fullDocSchema.parse(cleanedData);
+    } catch (error) {
+      console.error('Document validation error:', error);
+      throw new Error(
+        `Document validation failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
   return {
-    toFirestore: (modelObject: WithFieldValue<FirestoreDocument<T>>): DocumentData => {
-      const now = new Date();
-
-      const data = {
-        ...modelObject,
-        clientTimestamp: now,
-        serverTimestamp: null, // This will be set by the server
-      };
-
-      try {
-        // We don't validate the full document here because the server timestamp will be null
-        return data;
-      } catch (error) {
-        console.error('Validation error:', error);
-        throw new Error(
-          `Document validation failed: ${error instanceof Error ? error.message : String(error)}`
-        );
-      }
-    },
-
-    fromFirestore(
-      snapshot: QueryDocumentSnapshot<DocumentData>,
-      options?: SnapshotOptions
-    ): FirestoreDocument<T> {
-      const data = snapshot.data(options);
-
-      // Convert Firestore Timestamps to Dates
-      const cleanedData = {
-        ...data,
-        id: snapshot.id,
-        serverTimestamp:
-          data.serverTimestamp instanceof Timestamp
-            ? timestampToDate(data.serverTimestamp)
-            : data.serverTimestamp,
-        clientTimestamp:
-          data.clientTimestamp instanceof Timestamp
-            ? timestampToDate(data.clientTimestamp)
-            : data.clientTimestamp,
-      };
-
-      try {
-        // Create a new schema that includes the required fields
-        // without assuming schema has a shape property
-        const fullDocSchema = z
-          .object({
-            id: z.string(),
-            serverTimestamp: z.date().nullable(),
-            clientTimestamp: z.date(),
-            // Remaining fields from T will be handled via any
-            // since we can't reliably extract them from an arbitrary ZodType
-          })
-          .passthrough() as unknown as z.ZodType<FirestoreDocument<T>>;
-
-        // Validate the document matches our schema
-        return fullDocSchema.parse(cleanedData);
-      } catch (error) {
-        console.error('Document validation error:', error);
-        throw new Error(
-          `Document validation failed: ${error instanceof Error ? error.message : String(error)}`
-        );
-      }
-    },
+    toFirestore,
+    fromFirestore,
   };
 }
 
+/**
+ * イベントドキュメント用のコンバーターを作成する
+ * @param schema イベントデータのZodスキーマ
+ * @returns イベントドキュメント用のFirestoreデータコンバーター
+ */
 export function createEventConverter<T, E extends EventType = EventType>(
   schema: z.ZodType<T>
 ): FirestoreDataConverter<EventDocument<T, E>> {
+  /**
+   * イベントオブジェクトをFirestoreデータ形式に変換する
+   * @param modelObject 変換するイベントオブジェクト
+   * @returns Firestoreデータ
+   */
+  function toFirestore(modelObject: WithFieldValue<EventDocument<T, E>>): DocumentData {
+    const data = {
+      ...modelObject,
+      // Server timestamp will be set by Firestore
+    };
+
+    try {
+      // We don't validate the data here because serverTimestamp will be null initially
+      return data;
+    } catch (error) {
+      console.error('Validation error:', error);
+      throw new Error(
+        `Event validation failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  /**
+   * Firestoreデータをイベントオブジェクトに変換する
+   * @param snapshot Firestoreのクエリドキュメントスナップショット
+   * @param options スナップショットオプション
+   * @returns 変換されたイベントドキュメント
+   */
+  function fromFirestore(
+    snapshot: QueryDocumentSnapshot<DocumentData>,
+    options?: SnapshotOptions
+  ): EventDocument<T, E> {
+    const data = snapshot.data(options);
+
+    // Convert Firestore Timestamps to Dates
+    const cleanedData = {
+      ...data,
+      id: snapshot.id,
+      serverTimestamp:
+        data.serverTimestamp instanceof Timestamp
+          ? timestampToDate(data.serverTimestamp)
+          : data.serverTimestamp,
+      clientTimestamp:
+        data.clientTimestamp instanceof Timestamp
+          ? timestampToDate(data.clientTimestamp)
+          : data.clientTimestamp,
+    };
+
+    try {
+      // Fix the type casting by using unknown as intermediate type
+      const eventSchema = z.object({
+        id: z.string(),
+        entityId: z.string(),
+        type: z.string() as unknown as z.ZodType<E>,
+        data: schema,
+        serverTimestamp: z.date().nullable(),
+        clientTimestamp: z.date(),
+        metadata: z.record(z.unknown()).optional(),
+      }) as z.ZodType<EventDocument<T, E>>;
+
+      // Validate the event matches our schema
+      return eventSchema.parse(cleanedData);
+    } catch (error) {
+      console.error('Event validation error:', error);
+      throw new Error(
+        `Event validation failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
   return {
-    toFirestore: (modelObject: WithFieldValue<EventDocument<T, E>>): DocumentData => {
-      const data = {
-        ...modelObject,
-        // Server timestamp will be set by Firestore
-      };
-
-      try {
-        // We don't validate the data here because serverTimestamp will be null initially
-        return data;
-      } catch (error) {
-        console.error('Validation error:', error);
-        throw new Error(
-          `Event validation failed: ${error instanceof Error ? error.message : String(error)}`
-        );
-      }
-    },
-
-    fromFirestore(
-      snapshot: QueryDocumentSnapshot<DocumentData>,
-      options?: SnapshotOptions
-    ): EventDocument<T, E> {
-      const data = snapshot.data(options);
-
-      // Convert Firestore Timestamps to Dates
-      const cleanedData = {
-        ...data,
-        id: snapshot.id,
-        serverTimestamp:
-          data.serverTimestamp instanceof Timestamp
-            ? timestampToDate(data.serverTimestamp)
-            : data.serverTimestamp,
-        clientTimestamp:
-          data.clientTimestamp instanceof Timestamp
-            ? timestampToDate(data.clientTimestamp)
-            : data.clientTimestamp,
-      };
-
-      try {
-        // Fix the type casting by using unknown as intermediate type
-        const eventSchema = z.object({
-          id: z.string(),
-          entityId: z.string(),
-          type: z.string() as unknown as z.ZodType<E>,
-          data: schema,
-          serverTimestamp: z.date().nullable(),
-          clientTimestamp: z.date(),
-          metadata: z.record(z.unknown()).optional(),
-        }) as z.ZodType<EventDocument<T, E>>;
-
-        // Validate the event matches our schema
-        return eventSchema.parse(cleanedData);
-      } catch (error) {
-        console.error('Event validation error:', error);
-        throw new Error(
-          `Event validation failed: ${error instanceof Error ? error.message : String(error)}`
-        );
-      }
-    },
+    toFirestore,
+    fromFirestore,
   };
 }
 
+/**
+ * ドキュメントスナップショットをアプリケーションオブジェクトに変換する
+ * @param snapshot ドキュメントスナップショット
+ * @param converter 使用するFirestoreデータコンバーター
+ * @returns 変換されたドキュメントまたはnull（存在しない場合）
+ */
 export function convertDocumentSnapshot<T>(
   snapshot: DocumentSnapshot<DocumentData>,
   converter: FirestoreDataConverter<FirestoreDocument<T> | EventDocument<T>>

--- a/packages/firestore-generator/test/generator.test.ts
+++ b/packages/firestore-generator/test/generator.test.ts
@@ -1,7 +1,7 @@
 import type { Firestore, QueryConstraint } from 'firebase/firestore';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
-import { firestoreGenerator } from '../src/generator';
+import { createCollection } from '../src/generator';
 
 // Define a mock Firestore type for testing
 interface MockFirestore extends Partial<Firestore> {
@@ -44,7 +44,7 @@ vi.mock('../src/utils', async () => {
   };
 });
 
-describe('firestoreGenerator', () => {
+describe('createCollection', () => {
   const userSchema = z.object({
     name: z.string(),
     email: z.string().email(),
@@ -53,11 +53,11 @@ describe('firestoreGenerator', () => {
 
   type User = z.infer<typeof userSchema>;
 
-  let userCollection: ReturnType<typeof firestoreGenerator.createCollection<User>>;
+  let userCollection: ReturnType<typeof createCollection<User>>;
   const mockDb: MockFirestore = {};
 
   beforeEach(() => {
-    userCollection = firestoreGenerator.createCollection<User>('users', userSchema);
+    userCollection = createCollection<User>('users', userSchema);
     vi.clearAllMocks();
   });
 


### PR DESCRIPTION
## Summary
- Refactored firestore-generator package to use individual function exports for better tree shaking
- Added detailed JSDoc documentation in Japanese for better code readability
- Reorganized code to use named functions for clearer structure
- Fixed function naming conflicts
- Updated tests to use the new API pattern

## Test plan
- All tests are passing
- Package builds successfully
- Manual verification with apps/web package